### PR TITLE
Update: Rydmike results and test feature updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 Rainbench is designed to test the throughput of different reactive libraries. It's a simple benchmark that fills a bucket with raindrops.
 
-Each rain drop creates a subcription and the observable gets updated every millisecond, which should trigger a rebuild of each rain drop widget with its new position.
+Each rain drop creates a subscription, and the observable gets updated every millisecond,
+which should trigger a rebuild of each rain drop widget with its new position.
 
 The number of raindrops and the capacity of the bucket can be adjusted. The benchmark will run until the bucket is full. The time it takes to fill the bucket is recorded and displayed at the end of the benchmark.
 
@@ -10,7 +11,7 @@ The number of raindrops and the capacity of the bucket can be adjusted. The benc
 ## Results
 
 -   Release mode on linux
--   Benchmark is restarted after each run to prevent GC interference
+-   The benchmark is restarted after each run to prevent GC interference
 -   value_LB == value_listenable_builder
 -   `stream_builder` and `value_LB` are not perfect comparisons as they can only listen to 1 observable at a time... but they serve as a good baseline
 -   `solidart` implementation uses `SolidBuilder` which can only listen to a fixed number of observables so it's not a perfect comparison either.
@@ -18,7 +19,7 @@ The number of raindrops and the capacity of the bucket can be adjusted. The benc
 ### 20k raindrops and a bucket capacity of 30k
 
 | Library                                                 | Raindrops/s | Time to fill bucket |
-| ------------------------------------------------------- | ----------- | ------------------- |
+|---------------------------------------------------------|-------------|---------------------|
 | [state_beacon](https://pub.dev/packages/state_beacon)   | 5337        | 5.62s               |
 | value_LB                                                | 5030        | 5.96s               |
 | [mobx](https://pub.dev/packages/flutter_mobx)           | 4618        | 6.50s               |
@@ -31,4 +32,25 @@ The number of raindrops and the capacity of the bucket can be adjusted. The benc
 
 https://github.com/jinyus/rainbench/assets/30532952/e90f56b3-8ba9-44e8-996d-1c240bc3fa70
 
+## RydMike - Updated test runs (Feb 3, 2024)
 
+- Updated to use the latest version of each library
+- Added Signals option to use Watch instead of context.watch.
+- Fixed capability to actually select the option to use ValueNotifier with State Beacon.
+- Tested in release mode on macOS (M1 Pro), with Flutter 2.16.9.
+- The benchmark is restarted after each run to prevent GC interference.
+- Used 20k raindrops and a bucket capacity of 200k for longer tests.
+
+### 20k raindrops and a bucket capacity of 200k
+
+| Library                                                      | Raindrops/s | Time to fill bucket |
+|--------------------------------------------------------------|-------------|---------------------|
+| 1 [state_beacon](https://pub.dev/packages/state_beacon)      | 20288       | 9.9s                |
+| 2 [mobx](https://pub.dev/packages/flutter_mobx)              | 12934       | 15.5s               |
+| 3 [state_beacon VN](https://pub.dev/packages/state_beacon)   | 9467        | 21.1s               |
+| 4 value_LB (Throws exceptions after completion!!!)           | 9450        | 21.1s               |
+| 5 [solidart](https://pub.dev/packages/solidart)              | 9466        | 21.1s               |
+| 6 [signals Watch](https://pub.dev/packages/signals)          | 8662        | 23.1s               |
+| 7 [signals context(watch)](https://pub.dev/packages/signals) | 7843        | 25.5s               |
+| 8 [context_watch](https://pub.dev/packages/context_watch)    | 5504        | 36.3s               |
+| 9 stream_builder                                             | 4549        | 44.0s               |

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ https://github.com/jinyus/rainbench/assets/30532952/e90f56b3-8ba9-44e8-996d-1c24
 - Updated to use the latest version of each library
 - Added Signals option to use Watch instead of context.watch.
 - Fixed capability to actually select the option to use ValueNotifier with State Beacon.
-- Tested in release mode on macOS (M1 Pro), with Flutter 2.16.9.
+- Tested in release mode on macOS (M1 Pro), with Flutter 3.16.9.
 - The benchmark is restarted after each run to prevent GC interference.
 - Used 20k raindrops and a bucket capacity of 200k for longer tests.
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -25,10 +25,10 @@ final bucketFillBeacon = Beacon.writable(0.0);
 const _rainSpeed = 0.1;
 
 // Number of raindrops to fill bucket
-final _bucketCapacity = Beacon.writable(20000);
+final _bucketCapacity = Beacon.writable(200000);
 
 // Number of raindrops falling
-final rainDropCount = Beacon.writable(5000);
+final rainDropCount = Beacon.writable(20000);
 
 final showBeacon = Beacon.writable(false);
 
@@ -40,6 +40,7 @@ class ToolBar extends StatefulWidget {
     5000: '5k',
     10000: '10k',
     20000: '20k',
+    100000: '100k',
   };
   static const bucketCapacities = {
     5000: '5k',
@@ -48,6 +49,7 @@ class ToolBar extends StatefulWidget {
     30000: '30k',
     50000: '50k',
     100000: '100k',
+    200000: '200k',
   };
   static const List<double> rainSpeeds = [0.05, 0.1, 0.15, 0.2];
 
@@ -268,7 +270,8 @@ class BenchmarkPage extends StatelessWidget {
           ? switch (obs.type) {
               ObservableType.beacon => BeaconRain(),
               ObservableType.beaconVN => BeaconValueNotifierRain(),
-              ObservableType.signal => SignlaRain(),
+              ObservableType.signal => SignalRain(),
+              ObservableType.signalWatch => SignalRainWatch(),
               ObservableType.stream => StreamRain(),
               ObservableType.contextWatchVN => ContextWatchValueNotifierRain(),
               ObservableType.valueNotifier => ValueNotifierRain(),

--- a/lib/observables/beacon.dart
+++ b/lib/observables/beacon.dart
@@ -25,3 +25,29 @@ class BeaconObservable implements Observable {
     _observable = Beacon.writable(0.0);
   }
 }
+
+class BeaconObservableVn implements Observable {
+  @override
+  ObservableType get type => ObservableType.beaconVN;
+
+  var _observable = Beacon.writable(0.0);
+
+  WritableBeacon<double> get observable => _observable;
+
+  @override
+  double get value => _observable.peek();
+
+  @override
+  set value(double value) => _observable.set(value);
+
+  @override
+  VoidCallback subscribe(void Function(double p1) callback) {
+    return _observable.subscribe(callback);
+  }
+
+  @override
+  void dispose() {
+    _observable.dispose();
+    _observable = Beacon.writable(0.0);
+  }
+}

--- a/lib/observables/observable.dart
+++ b/lib/observables/observable.dart
@@ -7,8 +7,8 @@ import 'package:signals/signals_flutter.dart';
 import 'package:state_beacon/state_beacon.dart';
 
 part 'beacon.dart';
-part 'signal.dart';
 part 'mobx.dart';
+part 'signal.dart';
 part 'solidart.dart';
 part 'stream.dart';
 part 'value_notifier.dart';
@@ -17,6 +17,7 @@ enum ObservableType {
   beacon('state_beacon'),
   beaconVN('state_beacon VN'),
   signal('signals'),
+  signalWatch('signals_watch'),
   stream('stream'),
   valueNotifier('value_notifier'),
   contextWatchVN('context_watch VN'),
@@ -29,7 +30,9 @@ enum ObservableType {
 }
 
 final beaconObservable = BeaconObservable();
+final beaconObservableVn = BeaconObservableVn();
 final signalObservable = SignalObservable();
+final signalObservableWatch = SignalObservableWatch();
 final streamObservable = StreamObservable();
 final valueNotifierObservable = ValueNotifierObservable();
 final contextWatchVNObservable = ContextWatchValueNotifierObservable();
@@ -48,8 +51,9 @@ sealed class Observable {
 
     return switch (obsType) {
       ObservableType.beacon => beaconObservable,
-      ObservableType.beaconVN => beaconObservable,
+      ObservableType.beaconVN => beaconObservableVn,
       ObservableType.signal => signalObservable,
+      ObservableType.signalWatch => signalObservableWatch,
       ObservableType.stream => streamObservable,
       ObservableType.valueNotifier => valueNotifierObservable,
       ObservableType.contextWatchVN => contextWatchVNObservable,

--- a/lib/observables/signal.dart
+++ b/lib/observables/signal.dart
@@ -25,3 +25,29 @@ class SignalObservable implements Observable {
     _observable.dispose();
   }
 }
+
+class SignalObservableWatch implements Observable {
+  @override
+  ObservableType get type => ObservableType.signalWatch;
+
+  final _observable = signal(0.0);
+
+  Signal<double> get observable => _observable;
+
+  @override
+  double get value => _observable.peek();
+
+  @override
+  set value(double value) => _observable.set(value);
+
+  @override
+  VoidCallback subscribe(void Function(double p1) callback) {
+    return _observable.subscribe(callback);
+  }
+
+  @override
+  @override
+  void dispose() {
+    _observable.dispose();
+  }
+}

--- a/lib/rain/rain.dart
+++ b/lib/rain/rain.dart
@@ -4,6 +4,7 @@ import 'package:flutter_mobx/flutter_mobx.dart' as fmx;
 import 'package:rainbench/main.dart';
 import 'package:rainbench/observables/observable.dart';
 import 'package:signals/signals_flutter.dart';
+import 'package:state_beacon/state_beacon.dart';
 
 part 'beacon.dart';
 part 'mobx.dart';

--- a/lib/rain/signal.dart
+++ b/lib/rain/signal.dart
@@ -1,11 +1,11 @@
 part of 'rain.dart';
 
-class SignlaRain extends StatelessWidget {
-  const SignlaRain({super.key});
+class SignalRain extends StatelessWidget {
+  const SignalRain({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final screenWidth = MediaQuery.of(context).size.width;
+    final screenWidth = MediaQuery.sizeOf(context).width;
     return Stack(
       children: [
         // Cloud at top
@@ -18,6 +18,44 @@ class SignlaRain extends StatelessWidget {
             builder: (context) {
               final startingLeftOffset = (screenWidth - totalRowWidth) / 2;
               final val = signalObservable.observable.watch(context);
+              final row = i ~/ columns;
+              final col = i % columns;
+              return Positioned(
+                left: startingLeftOffset + col * (dropWidth + dropSpacing),
+                top: initialTopOffset +
+                    row * dropSpacing +
+                    200.0 * (1 + (val * .1)),
+                child: const Icon(
+                  Icons.water_drop,
+                  size: dropWidth,
+                  color: Colors.blue,
+                ),
+              );
+            },
+          ),
+      ],
+    );
+  }
+}
+
+class SignalRainWatch extends StatelessWidget {
+  const SignalRainWatch({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final screenWidth = MediaQuery.sizeOf(context).width;
+    return Stack(
+      children: [
+        // Cloud at top
+        Clouds(screenWidth: screenWidth),
+        const Progress(),
+
+        // Raining drops based on beacon position
+        for (int i = 0; i < rainDropCount.peek(); i++)
+          Watch(
+            (BuildContext context) {
+              final startingLeftOffset = (screenWidth - totalRowWidth) / 2;
+              final val = signalObservableWatch.observable.value;
               final row = i ~/ columns;
               final col = i % columns;
               return Positioned(

--- a/lib/rain/value_notifier.dart
+++ b/lib/rain/value_notifier.dart
@@ -99,7 +99,7 @@ class BeaconValueNotifierRain extends StatelessWidget {
         // Raining drops based on beacon position
         for (int i = 0; i < rainDropCount.peek(); i++)
           ValueListenableBuilder(
-            valueListenable: beaconObservable.observable,
+            valueListenable: beaconObservableVn.observable.toListenable(),
             builder: (ctx, val, child) {
               // print('VN $val');
               final startingLeftOffset = (screenWidth - totalRowWidth) / 2;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -34,10 +34,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_mobx
-      sha256: "0f0463db8a1582ac88670bea6e4f58ab64a16d701bc7d2c27ea50c1dbe5aecdc"
+      sha256: "4a5d062ff85ed3759f4aac6410ff0ffae32e324b2e71ca722ae1b37b32e865f4"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0+1"
+    version: "2.2.0+2"
   flutter_solidart:
     dependency: "direct main"
     description:
@@ -66,10 +66,10 @@ packages:
     dependency: "direct main"
     description:
       name: mobx
-      sha256: "6b467f91bfc534922ea670db69a1972d28bd9754085892decb5bce19f2c8d0d5"
+      sha256: "74ee54012dc7c1b3276eaa960a600a7418ef5f9997565deb8fca1fd88fb36b78"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "2.3.0+1"
   nested:
     dependency: transitive
     description:
@@ -98,26 +98,26 @@ packages:
     dependency: "direct main"
     description:
       name: signals
-      sha256: a7ba857a3a6955404e0ba868f86d8490d4c04604766c65ccefb7ba807ef70e42
+      sha256: fb15f1f60027799a5294e048a0c46e63efefeff4d5f5bfe9c61b2552ae852abf
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.10"
+    version: "3.0.0"
   signals_core:
     dependency: transitive
     description:
       name: signals_core
-      sha256: "96ca555b5881d1b7a7b521cec9ac64c56eacc75b54a79a76e73eb0d7bcbad82e"
+      sha256: "79ca5a5ebca67eba54f6b271f8ac7adf1250717fb5d947295e77dd34610cabac"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.6"
+    version: "3.0.0"
   signals_flutter:
     dependency: transitive
     description:
       name: signals_flutter
-      sha256: ab0e7376fd4b1fbf2f427d431bcf35a1eb2251308feb35f7b770b6f95b5677e6
+      sha256: "85b15c10a042da332d11ca989b8b038802fe2effe2c6dc29ecbd02becec1bba5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.8"
+    version: "3.0.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -135,10 +135,18 @@ packages:
     dependency: "direct main"
     description:
       name: state_beacon
-      sha256: d399ef3fc8a3b9916abfe1089f59d52737c7d4e30447d3e96051f8f242e46085
+      sha256: aef3aa3505e02697716fda15c3a13f7051a5b46ef7ae9b4ed2a21dbc05b0a4aa
       url: "https://pub.dev"
     source: hosted
-    version: "0.14.6"
+    version: "0.33.1"
+  state_beacon_core:
+    dependency: transitive
+    description:
+      name: state_beacon_core
+      sha256: "99777ecd401e45bfd7f6e8af5bc31421a3f98ff6fd38b2430440b09c4f9057ed"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.33.1"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,11 +10,11 @@ dependencies:
     context_watch: ^1.0.2
     flutter:
         sdk: flutter
-    flutter_mobx: ^2.2.0+1
+    flutter_mobx: ^2.2.0+2
     flutter_solidart: ^1.7.0
     mobx: ^2.3.0
-    signals: ^2.1.10
-    state_beacon: ^0.14.6
+    signals: ^3.0.0
+    state_beacon: ^0.33.1
 
 dev_dependencies:
     very_good_analysis: ^5.1.0


### PR DESCRIPTION
Hi, not sure if you are interested in updates to to this repo, but I just updated it to be able to use the benchmark with latest PKG versions. I did some small fixes to the tests. I ran them all with a bit longer runs as well and included my results.

## RydMike - Updated test runs (Feb 3, 2024)

- Updated to use the latest version of each library
- Added Signals option to use Watch instead of context.watch.
- Fixed capability to actually select the option to use ValueNotifier with State Beacon.
- Tested in release mode on macOS (M1 Pro), with Flutter 3.16.9.
- The benchmark is restarted after each run to prevent GC interference.
- Used 20k raindrops and a bucket capacity of 200k for longer tests.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [x] 🗑️ Chore
